### PR TITLE
Enhance Database Code:

### DIFF
--- a/CSChatBot-Core/CSChatBot-Core/Modules/Admin.cs
+++ b/CSChatBot-Core/CSChatBot-Core/Modules/Admin.cs
@@ -92,6 +92,7 @@ namespace CSChatBot.Modules
             if (target != null && target.ID != args.SourceUser.ID)
             {
                 target.IsBotAdmin = true;
+                target.Save(args.DatabaseInstance);
                 return new CommandResponse($"{target.Name} is now a bot admin.");
             }
             return new CommandResponse(null);
@@ -104,6 +105,7 @@ namespace CSChatBot.Modules
             if (target != null && target.ID != args.SourceUser.ID)
             {
                 target.IsBotAdmin = false;
+                target.Save(args.DatabaseInstance);
                 return new CommandResponse($"{target.Name} is no longer a bot admin.");
             }
             return new CommandResponse(null);

--- a/CSChatBot-Core/CSChatBot-Core/Modules/TestModule.cs
+++ b/CSChatBot-Core/CSChatBot-Core/Modules/TestModule.cs
@@ -49,7 +49,7 @@ namespace CSChatBot.Modules
                 new InlineKeyboardButton()
                 {
                     Text = "Grey Wolf Dev Channel",
-                    Url="https://t.me/werewolfdev"
+                    Url="https://t.me/greywolfdev"
                 },
                 //can also use conditional statements when building menus
                 true ? new InlineKeyboardButton() {Text = "Para's Channel", Url="https://t.me/para949"} : null
@@ -110,16 +110,16 @@ namespace CSChatBot.Modules
             var b = args.Bot;
 
             b.SendTextMessageAsync(id, "Getting boolean value, default false.");
-            var value = group.GetSetting<bool>("TestBool", args.DatabaseInstance, false);
+            var value = group.GetSetting("TestBool", args.DatabaseInstance, false);
             Thread.Sleep(500);
             b.SendTextMessageAsync(id, $"Result: {value}\nSetting to true...");
-            var success = group.SetSetting<bool>("TestBool", args.DatabaseInstance, false, true);
-            value = group.GetSetting<bool>("TestBool", args.DatabaseInstance, false);
+            var success = group.SetSetting("TestBool", args.DatabaseInstance, false, true);
+            value = group.GetSetting("TestBool", args.DatabaseInstance, false);
             Thread.Sleep(500);
             b.SendTextMessageAsync(id, $"Update result: {success}\nCurrent value for test setting: {value}\nSetting to false");
 
-            success = group.SetSetting<bool>("TestBool", args.DatabaseInstance, false, false);
-            value = group.GetSetting<bool>("TestBool", args.DatabaseInstance, false);
+            success = group.SetSetting("TestBool", args.DatabaseInstance, false, false);
+            value = group.GetSetting("TestBool", args.DatabaseInstance, false);
             Thread.Sleep(500);
             b.SendTextMessageAsync(id, $"Update result: {success}\nCurrent value for test setting: {value}");
             return null;

--- a/CSChatBot-Core/DB/Instance.cs
+++ b/CSChatBot-Core/DB/Instance.cs
@@ -74,29 +74,29 @@ namespace DB
 
         public User GetUser(int ID)
         {
-            return Connection.Query<User>($"select * from users where ID = {ID}").FirstOrDefault();
+            return Connection.Query<User>($"select * from users where ID = @ID", new { ID }).FirstOrDefault();
         }
 
         [Obsolete("Do not search by name, Telegram allows multiple users with same name")]
         public User GetUserByName(string nick)
         {
-            return Connection.Query<User>($"select * from users where Name = '{nick}'").FirstOrDefault();
+            return Connection.Query<User>($"select * from users where Name = @nick", new { nick }).FirstOrDefault();
         }
 
         public User GetUserById(int Id)
         {
-            return Connection.Query<User>($"select * from users where UserId = {Id}").FirstOrDefault();
+            return Connection.Query<User>($"select * from users where UserId = @Id", new { Id }).FirstOrDefault();
         }
 
         public Group GetGroup(int ID)
         {
-            return Connection.Query<Group>($"select * from chatgroup where ID = {ID}").FirstOrDefault();
+            return Connection.Query<Group>($"select * from chatgroup where ID = @ID", new { ID }).FirstOrDefault();
         }
 
 
         public Group GetGroupById(long Id)
         {
-            return Connection.Query<Group>($"select * from chatgroup where GroupId = {Id}").FirstOrDefault();
+            return Connection.Query<Group>($"select * from chatgroup where GroupId = @Id", new { Id }).FirstOrDefault();
         }
     }
 }

--- a/CSChatBot-Core/Giveaway/Extensions/Extensions.cs
+++ b/CSChatBot-Core/Giveaway/Extensions/Extensions.cs
@@ -33,13 +33,13 @@ namespace Giveaway.Extensions
 
         public static bool HasActiveGiveaway(this User u, Instance db)
         {
-            var rows = db.Connection.Query($"SELECT COUNT(1) as 'Count' FROM giveaway WHERE Owner = '{u.UserId}' AND Active = 1");
+            var rows = db.Connection.Query($"SELECT COUNT(1) as 'Count' FROM giveaway WHERE Owner = @UserId AND Active = 1", u);
             return (int)rows.First().Count > 0;
         }
 
         public static bool ExistsInDb(this Models.Giveaway g, Instance db)
         {
-            var rows = db.Connection.Query($"SELECT COUNT(1) as 'Count' FROM giveaway WHERE ID = '{g.ID}'");
+            var rows = db.Connection.Query($"SELECT COUNT(1) as 'Count' FROM giveaway WHERE ID = @ID", g);
             return (int)rows.First().Count > 0;
         }
 
@@ -50,31 +50,31 @@ namespace Giveaway.Extensions
 
         public static bool HasUser(this Models.Giveaway g, Instance db, int userid)
         {
-            var rows = db.Connection.Query($"SELECT COUNT(1) as 'Count' FROM giveawayuser WHERE UserId = '{userid}' AND GiveawayId = '{g.ID}'");
+            var rows = db.Connection.Query($"SELECT COUNT(1) as 'Count' FROM giveawayuser WHERE UserId = @userid AND GiveawayId = @ID", new { userid, g.ID });
             return (int)rows.First().Count > 0;
         }
 
         public static void AddUser(this Models.Giveaway g, Instance db, int userid)
         {
             db.ExecuteNonQuery(
-                    $"insert into giveawayuser (UserId, GiveawayId) VALUES ({userid}, {g.ID})");
+                    $"insert into giveawayuser (UserId, GiveawayId) VALUES (@userid, @ID)", new { userid, g.ID });
         }
 
         public static Models.Giveaway GetGiveaway(this Instance db, string id)
         {
 
-            return db.Connection.Query<Models.Giveaway>($"select * from giveaway WHERE ID = {id} ").FirstOrDefault();
+            return db.Connection.Query<Models.Giveaway>($"select * from giveaway WHERE ID = @id", new { id }).FirstOrDefault();
         }
 
         public static Models.Giveaway GetGiveaway(this Instance db, User u, bool active = true)
         {
             var a = active ? 1 : 0;
-            return db.Connection.Query<Models.Giveaway>($"select * from giveaway WHERE Owner = {u.UserId} AND Active = {a} order by ID desc").FirstOrDefault();
+            return db.Connection.Query<Models.Giveaway>($"select * from giveaway WHERE Owner = @UserId AND Active = @a order by ID desc", new { u.UserId, a }).FirstOrDefault();
         }
 
         public static IEnumerable<User> GetUsers(this Models.Giveaway g, Instance db)
         {
-            var userIds = db.Connection.Query<int>($"select UserId from giveawayuser where GiveawayId = {g.ID}").ToList();
+            var userIds = db.Connection.Query<int>($"select UserId from giveawayuser where GiveawayId = @ID", g).ToList();
             return db.Users.Where(x => userIds.Contains(x.UserId));
         }
         #endregion

--- a/CSChatBot-Core/Steam/Steam.cs
+++ b/CSChatBot-Core/Steam/Steam.cs
@@ -23,15 +23,14 @@ namespace Steam
         private static string _steamKey;
         public Steam(Instance db, Setting settings, TelegramBotClient bot)
         {
-            settings.AddField(db, "SteamKey");
-            var steamKey = settings.GetString(db, "SteamKey");
+            var steamKey = settings.GetSetting("SteamKey", db, "");
             if (String.IsNullOrWhiteSpace(steamKey))
             {
                 //now ask for the API Key
                 Console.Clear();
                 Console.Write("What is your Steam API key? : ");
                 steamKey = Console.ReadLine();
-                settings.SetString(db, "SteamKey", steamKey);
+                settings.SetSetting("SteamKey", db, "", steamKey);
             }
             if (String.IsNullOrEmpty(steamKey)) return;
             _steamKey = steamKey;


### PR DESCRIPTION
 [x] Explicitly using the type argument when setting/getting a setting from the database now obsolete
 [x] Make use of Dapper's parameterization where possible to avoid SQL injection
 [x] Escape the rest of the strings in queries manually to avoid SQL injection
 [x] Avoid crashing for `GetSetting<int>` (SQLite saves all integers as 64-bit, so they need to be converted)
 [x] Unify the way `SetSettings` and `GetSettings` work for users, groups and settings
 [x] Make addbotadmin and rembotadmin work (the change needs to be saved to the database)